### PR TITLE
Restore static and media ROOT and URL.

### DIFF
--- a/trail/trail/settings.py
+++ b/trail/trail/settings.py
@@ -131,7 +131,10 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
-
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'
 
 ADMIN_MEDIA_PREFIX = '/media/'


### PR DESCRIPTION
This is required for file hosting with Django. Everything else just accidentally works in debug mode.

I'm not sure we need `ADMIN_MEDIA_PREFIX` but I guess if we ever build tools for admin we might. In any case it should probably point away from `/media/` but isn't a problem now.