### PR TITLE
Use Sequence to avoid issues with typing.List vs list.

### DIFF
--- a/trail/upload/models.py
+++ b/trail/upload/models.py
@@ -4,7 +4,8 @@ support working with the data.
 """
 
 
-from dataclasses import dataclass, make_dataclass, field, InitVar, asdict
+from dataclasses import dataclass, field
+from typing import Sequence
 
 from django.db import models
 import numpy as np
@@ -234,7 +235,7 @@ class StandardizedHeader:
     standardized WCS.
     """
     metadata: Metadata = None
-    wcs: list[Wcs] = field(default_factory=list)
+    wcs: Sequence[Wcs] = field(default_factory=list)
 
     @classmethod
     def fromDict(cls, data):


### PR DESCRIPTION
In Python 3.9 dataclasses can seemingly define their fields using just a `list` whereas in Python 3.8 that's an error. Reading online about it I found out that `typingSequence` should preferentially be used for type annotation of arguments and `typing.List` for return values. 

Moved the `list` to `Sequence` which will also, hopefully, avoid the pitfall of the 3.8 vs 3.9 errors.
Fixes issue https://github.com/dirac-institute/trailblazer/issues/19