### PR TITLE
Logging

### DIFF
--- a/trail/logging.cfg
+++ b/trail/logging.cfg
@@ -1,0 +1,51 @@
+version: 1
+disable_existing_loggers: False
+
+filters: 
+    require_debug_false: 
+        (): django.utils.log.RequireDebugFalse    
+    require_debug_true: 
+        (): django.utils.log.RequireDebugTrue
+
+formatters: 
+    django.server: 
+        (): django.utils.log.ServerFormatter
+        format: "{levelname:<10} {asctime:<25} {message}"
+        style: "{"
+
+handlers: 
+    console: 
+        level: INFO
+        filters: [require_debug_true]
+        class: logging.StreamHandler
+        formatter: django.server
+    django.server: 
+        level: INFO
+        class: logging.StreamHandler
+        formatter: django.server
+    mail_admins: 
+        level: ERROR
+        filters: [require_debug_false]
+        class: django.utils.log.AdminEmailHandler
+    processing: 
+        level: INFO
+        class: logging.FileHandler
+        filename: processing.log
+        formatter: django.server
+
+loggers: 
+    django: 
+        handlers: [console, mail_admins]
+        level: INFO  
+    django.server: 
+        handlers: [django.server]
+        level: INFO
+        propagate: False
+    astro_metadata_translator: 
+        handlers: [console, processing]
+        level: INFO
+    upload: 
+        handlers: [console, processing]
+        level: INFO
+    
+    

--- a/trail/trail/settings.py
+++ b/trail/trail/settings.py
@@ -60,6 +60,71 @@ INSTALLED_APPS = [
     'trail',
 ]
 
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
+        },
+    },
+    'formatters': {
+        'django.server': {
+            '()': 'django.utils.log.ServerFormatter',
+            'format': '{levelname:<10} {asctime:<25} {message}',
+            'style': '{',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'filters': ['require_debug_true'],
+            'class': 'logging.StreamHandler',
+            'formatter': 'django.server'
+        },
+        'django.server': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'django.server',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+        'processing': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': "processing.log",
+            'formatter': 'django.server',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'INFO',
+        },
+        'django.server': {
+            'handlers': ['django.server'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'astro_metadata_translator': {
+            'handlers': ['console', 'processing'],
+            'level': 'INFO',
+        },
+        'upload.process_uploads': {
+            'handlers': ['console', 'processing'],
+            'level': 'INFO',
+        },
+    }
+}
+
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/trail/trail/settings.py
+++ b/trail/trail/settings.py
@@ -13,18 +13,15 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 from pathlib import Path
 import os
 
-from .config import DbAuth, SiteConfig
+from . import config
 
 
 TRAILBLAZER_ENV = os.environ.get("TRAILBLAZER_ENVIRONMENT", default="local")
 if TRAILBLAZER_ENV == "local":
-    # instantiate with "nonsense" default values
-    siteConfig = SiteConfig()
-    dbConfig = DbAuth()
+    # avoids problematic Windows file permissions when loading default YAMLs
+    siteConf = config.SecretsConfig()
 else:
-    # instantiate from a secrets file
-    siteConfig = SiteConfig.fromYaml()
-    dbConfig = DbAuth.fromYaml()
+    siteConf = config.SecretsConfig.fromYaml(config.get_secrets_filepath())
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -35,18 +32,18 @@ REPO_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
-
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = siteConfig.secret_key
+SECRET_KEY = siteConf.django.secret_key
+
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = siteConf.django.debug
+
 
 ALLOWED_HOSTS = []
 
 
 # Application definition
-
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -61,68 +58,8 @@ INSTALLED_APPS = [
 ]
 
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse',
-        },
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue',
-        },
-    },
-    'formatters': {
-        'django.server': {
-            '()': 'django.utils.log.ServerFormatter',
-            'format': '{levelname:<10} {asctime:<25} {message}',
-            'style': '{',
-        }
-    },
-    'handlers': {
-        'console': {
-            'level': 'INFO',
-            'filters': ['require_debug_true'],
-            'class': 'logging.StreamHandler',
-            'formatter': 'django.server'
-        },
-        'django.server': {
-            'level': 'INFO',
-            'class': 'logging.StreamHandler',
-            'formatter': 'django.server',
-        },
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        },
-        'processing': {
-            'level': 'INFO',
-            'class': 'logging.FileHandler',
-            'filename': "processing.log",
-            'formatter': 'django.server',
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
-        },
-        'django.server': {
-            'handlers': ['django.server'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-        'astro_metadata_translator': {
-            'handlers': ['console', 'processing'],
-            'level': 'INFO',
-        },
-        'upload.process_uploads': {
-            'handlers': ['console', 'processing'],
-            'level': 'INFO',
-        },
-    }
-}
+loggingConf = config.Config.fromYaml(BASE_DIR / "logging.cfg")
+LOGGING = loggingConf.asDict()
 
 
 MIDDLEWARE = [
@@ -135,7 +72,9 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+
 ROOT_URLCONF = 'trail.urls'
+
 
 TEMPLATES = [
     {
@@ -153,12 +92,13 @@ TEMPLATES = [
     },
 ]
 
+
 WSGI_APPLICATION = 'trail.wsgi.application'
 
 
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
-DATABASES = {"default": dbConfig.asDict()}
+DATABASES = {"default": siteConf.db.asDict(capitalizeKeys=True)}
 
 
 # Password validation

--- a/trail/trail/tests/config/conf.yaml
+++ b/trail/trail/tests/config/conf.yaml
@@ -1,4 +1,4 @@
-settings:
+django:
   secret_key: nonsense
   static_root: ~/trail/static
   media_root: ~/trail/media

--- a/trail/upload/process_uploads/upload_processor.py
+++ b/trail/upload/process_uploads/upload_processor.py
@@ -4,7 +4,6 @@ Class that facilitates the processing of an uplod.
 
 
 from abc import ABC, abstractmethod
-import warnings
 import logging
 
 from django.conf import settings
@@ -146,11 +145,8 @@ class UploadProcessor(ABC):
                 # I think this should never be an issue really, but just in case
                 names = [proc.name for proc in processors]
                 logger.info("Multiple processors declared ability to process "
-                             f"the given upload: {names}. Using {names[-1]} "
-                             "to process FITS.")
-                #warnings.warn("Multiple processors declared ability to process "
-                #              f"the given upload: {names}. \n Using {names[-1]} "
-                #              "to process FITS.")
+                            f"the given upload: {names}. Using {names[-1]} "
+                            "to process FITS.")
             return processors[0]
         else:
             raise ValueError("None of the known processors can handle this upload.\n "

--- a/trail/upload/process_uploads/upload_processor.py
+++ b/trail/upload/process_uploads/upload_processor.py
@@ -5,6 +5,7 @@ Class that facilitates the processing of an uplod.
 
 from abc import ABC, abstractmethod
 import warnings
+import logging
 
 from django.conf import settings
 
@@ -13,6 +14,9 @@ from .upload_wrapper import TemporaryUploadedFileWrapper
 
 
 __all__ = ["UploadProcessor", "get_ip"]
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_ip(request):
@@ -141,9 +145,12 @@ class UploadProcessor(ABC):
             if len(processors) > 1:
                 # I think this should never be an issue really, but just in case
                 names = [proc.name for proc in processors]
-                warnings.warn("Multiple processors declared ability to process "
-                              f"the given upload: {names}. \n Using {names[-1]} "
-                              "to process FITS.")
+                logger.info("Multiple processors declared ability to process "
+                             f"the given upload: {names}. Using {names[-1]} "
+                             "to process FITS.")
+                #warnings.warn("Multiple processors declared ability to process "
+                #              f"the given upload: {names}. \n Using {names[-1]} "
+                #              "to process FITS.")
             return processors[0]
         else:
             raise ValueError("None of the known processors can handle this upload.\n "

--- a/trail/upload/views.py
+++ b/trail/upload/views.py
@@ -1,5 +1,6 @@
 """This code runs when a user visits the 'upload' URL."""
 
+
 from django.urls import reverse_lazy
 from django.views.generic.edit import FormView
 from .forms import FileFieldForm


### PR DESCRIPTION
Add logging to upload processing.

Redirect upload processing logs to console and file in debug mode, log unique upload IDs so logs can at least partially be parsed. Redirect `astro_metadata_translator` logs to processing logs. Store processing logs in file in and out of DEBUG mode.

Crucial logs to send email notification on ERROR events to admins members.
    
Refactor config class. Fix tests.