### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -28,4 +28,4 @@ jobs:
       - name: Run tests
         run: |
           cd trail
-          python manage.py test -v2 -b
+          python -W error::DeprecationWarning manage.py test -v2 -b

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -2,7 +2,7 @@ name: "Test current stable Python releases"
 
 on:
   schedule:
-    - chron: "0 30 15 ? * MON * "
+    - cron: "30 15 * * MON"
 
 jobs:
   main:
@@ -29,3 +29,4 @@ jobs:
         run: |
           cd trail
           python -W error::DeprecationWarning manage.py test -v2 -b
+

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install newest astro_metadata_translator
         run: |
           git clone https://github.com/lsst/astro_metadata_translator.git
-          pip install astro_metadata_translator
+          pip install astro_metadata_translator/
       - name: Run tests
         run: |
           cd trail

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -1,0 +1,31 @@
+name: "Test current stable Python releases"
+
+on:
+  schedule:
+    - chron: "0 30 15 ? * MON * "
+
+jobs:
+  main:
+    name: Canary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: "main"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.X"
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install newest astro_metadata_translator
+        run: |
+          git clone https://github.com/lsst/astro_metadata_translator.git
+          pip install astro_metadata_translator
+      - name: Run tests
+        run: |
+          cd trail
+          python manage.py test -v2 -b

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -50,9 +50,7 @@ jobs:
       - name: Install newest astro_metadata_translator
         run: |
           git clone https://github.com/lsst/astro_metadata_translator.git
-          cd astro_metadata_translator
-          python setup.py install
-          cd ..
+          pip install astro_metadata_translator
       - name: Run tests
         run: |
           cd trail
@@ -86,9 +84,7 @@ jobs:
       - name: Install newest astro_metadata_translator
         run: |
           git clone https://github.com/lsst/astro_metadata_translator.git
-          cd astro_metadata_translator
-          python setup.py install
-          cd ..
+          pip install astro_metadata_translator
       - name: Run tests
         run: |
           cd trail

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install newest astro_metadata_translator
         run: |
           git clone https://github.com/lsst/astro_metadata_translator.git
-          pip install astro_metadata_translator
+          pip install astro_metadata_translator/
       - name: Run tests
         run: |
           cd trail
@@ -84,7 +84,7 @@ jobs:
       - name: Install newest astro_metadata_translator
         run: |
           git clone https://github.com/lsst/astro_metadata_translator.git
-          pip install astro_metadata_translator
+          pip install astro_metadata_translator/
       - name: Run tests
         run: |
           cd trail

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,9 @@ numpy==1.20.1
 photutils==1.1.0
 Pillow==8.1.2
 pyerfa==1.7.2
+PyQt5==5.15.6
+PyQt5-Qt5==5.15.2
+PyQt5-sip==12.9.1
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2021.1


### PR DESCRIPTION
Explicitly set python version requirements. 
Add a scheduled GA on the latest stable python version on every Monday.