### PR TITLE
Fix wrong path to upload_button_state JS script.

### DIFF
--- a/trail/upload/forms.py
+++ b/trail/upload/forms.py
@@ -49,6 +49,7 @@ class UploadForm(forms.Form):
         }
         js = (
             'assets/js/upload_form.js',
+            'assets/js/upload_button_state.js',
             'assets/js/filelist.js',
         )
 

--- a/trail/upload/templates/upload.html
+++ b/trail/upload/templates/upload.html
@@ -15,5 +15,4 @@
 {% block content.scripts.extended %}
 {{block.super}}
 {{form.media}}
-<script src="/static/upload_button_state.js"></script>
 {% endblock %}


### PR DESCRIPTION
Path to JS script that controlled the upload button state was hardcoded in the HTML template with a wrong path. This accidentally worked locally but does not work in general. 

Path is now set in the `UploadForm` class itself and points to correct location.