### PR TITLE
Add Whipple Observatory header standardizer.

### DIFF
--- a/trail/trail/settings.py
+++ b/trail/trail/settings.py
@@ -30,7 +30,6 @@ TRAILBLAZER_CONFIG_DIR = Path(os.environ.get("TRAILBLAZER_CONFIG_DIR",
 siteConfig = config.Config.fromYaml(TRAILBLAZER_CONFIG_DIR / "site.yaml")
 loggingConfig = config.Config.fromYaml(TRAILBLAZER_CONFIG_DIR / "logging.yaml")
 
-
 # avoids problematic Windows file permissions when loading default YAMLs by
 # instantiating from existing hardcoded defaults...
 if TRAILBLAZER_ENV == "local":
@@ -58,10 +57,8 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = SMALL_THUMB_ROOT
 MEDIA_URL = '/media/'
 
-# ASTROMETRY_KEY = siteConfig.astrometry_net.key
-# ASTROMETRY_TIMEOUT = siteConfig.astrometry_net.timeout
-ASTROMETRY_KEY = ""
-ASTROMETRY_TIMEOUT = ""
+ASTROMETRY_KEY = siteConfig.astrometry_net.key
+ASTROMETRY_TIMEOUT = siteConfig.astrometry_net.timeout
 
 if "gallery_image_count" in siteConfig:
     GALLERY_IMAGE_COUNT = siteConfig.gallery_image_count
@@ -179,6 +176,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+# max filesize, in bytes, before it's streamed to disk
+FILE_UPLOAD_MAX_MEMORY_SIZE = 521440
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/

--- a/trail/upload/forms.py
+++ b/trail/upload/forms.py
@@ -111,7 +111,7 @@ class UploadForm(forms.Form):
                 "standardizer": res.metadata.standardizer_name,
                 "obs_lon": round(res.metadata.obs_lon, 2),
                 "obs_lat": round(res.metadata.obs_lat, 2),
-                "datetime": res.metadata.datetime_begin.replace("T", " "),
+                "datetime": res.metadata.datetime_begin
             })
 
         html = render_to_string(

--- a/trail/upload/process_uploads/fits_processor.py
+++ b/trail/upload/process_uploads/fits_processor.py
@@ -189,7 +189,7 @@ class FitsProcessor(UploadProcessor):
         # docstring inherited from UploadProcessor; TODO: check it's True
         canProcess, hdulist = False, None
 
-        if uploadedFile.extension in cls.extensions:
+        if uploadedFile.extension.lower() in cls.extensions:
             try:
                 hdulist = fits.open(uploadedFile.tmpfile.temporary_file_path())
             except OSError:

--- a/trail/upload/process_uploads/standardizers/__init__.py
+++ b/trail/upload/process_uploads/standardizers/__init__.py
@@ -6,3 +6,4 @@ from .gemini_north_standardizer import *
 from .lowell_standardizer import *
 from .lbt_standardizer import *
 from .vatt_standardizer import *
+from .whipple_standardizer import *

--- a/trail/upload/process_uploads/standardizers/whipple_standardizer.py
+++ b/trail/upload/process_uploads/standardizers/whipple_standardizer.py
@@ -37,7 +37,15 @@ class WhippleStandardizer(HeaderStandardizer):
         # (height specifically) and implement conditions to handle them
         # http://www.sao.arizona.edu/FLWO/whipple.html
         # This is the Ridge location height
-        height = 2340
+        height = self.header.get("HEIGHT", None)
+        if height is None:
+            if "cecilia" in self.header["TELESCOP"].lower() or "ben" in self.header["TELESCOP"]:
+                height = 1268.00
+            else:
+                raise RuntimeError(
+                    "Unable to parse height of the instrument. Header does "
+                    "not contain key HEIGHT or is not one of the supported "
+                    "known instruments at Whipple Observatory.")
 
         meta = Metadata(
             obs_lon=self.header["LONGITUD"],

--- a/trail/upload/process_uploads/standardizers/whipple_standardizer.py
+++ b/trail/upload/process_uploads/standardizers/whipple_standardizer.py
@@ -1,0 +1,55 @@
+"""
+Class that facilitates header metadata translation for Las Cumbres Observatory.
+"""
+
+from datetime import datetime, timezone
+
+from upload.process_uploads.header_standardizer import HeaderStandardizer
+from upload.models import Metadata
+
+
+__all__ = ["WhippleStandardizer", ]
+
+
+class WhippleStandardizer(HeaderStandardizer):
+
+    name = "whipple_standardizer"
+    priority = 1
+
+    def __init__(self, header, **kwargs):
+        super().__init__(header, **kwargs)
+
+    @classmethod
+    def canStandardize(self, header, **kwargs):
+        observat = header.get("OBSERVAT", False)
+        if observat and "WHIPPLE" in observat.upper():
+            return True
+        return False
+
+    def standardizeMetadata(self):
+        startt = datetime.strptime(self.header["DATE-OBS"], "%Y-%m-%dT%H:%M:%S.%f%z")
+        endt = datetime.strptime(self.header["DATE-END"], "%Y-%m-%dT%H:%M:%S.%f%z")
+        startt = startt.astimezone(timezone.utc)
+        endt = endt.astimezone(timezone.utc)
+
+        # TODO: there are multiple different telescopes
+        # at the Whipple Obs site, check if there are any particularities
+        # (height specifically) and implement conditions to handle them
+        # http://www.sao.arizona.edu/FLWO/whipple.html
+        # This is the Ridge location height
+        height = 2340
+
+        meta = Metadata(
+            obs_lon=self.header["LONGITUD"],
+            obs_lat=self.header["LATITUDE"],
+            obs_height=height,
+            datetime_begin=startt,
+            datetime_end=endt,
+            telescope=self.header["TELESCOP"],
+            instrument=self.header["INSTRUME"],
+            science_program=f"{self.header['ORIGIN']} {self.header['OBSID']}",
+            exposure_duration=self.header["EXPTIME"],
+            filter_name=self.header["FILTER"]
+        )
+
+        return meta


### PR DESCRIPTION
The main problem with Whipple observatory files is that they are smaller than 1MB, which made Django never write them to temporary file, which made AstroPy fail to open them. Second issue was that I didn't account for lower/uppercase file extensions.

I went ahead and added a simple header standardizer for Whipple. It does not cover all of the telescopes at that site. This should be fixed/expanded on in the future. 

An erroneous commit https://github.com/dirac-institute/trailblazer/commit/e960757c7f2c61f97924c24c911c16c4bf93392a commented out the default ASTROMETRY.NET setting. This wasn't caught because the deployed website settings file diverged and didn't have this issue and nobody manually tested if upload to astrometry.net worked.